### PR TITLE
Proposed changes to the internal API

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,6 +15,7 @@
 
     <ItemGroup>
         <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
+        <PackageVersion Include="SkiaSharp" Version="3.119.0" />
 
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
         <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />

--- a/src/IconPacks.Avalonia/IconPacks.Avalonia.csproj
+++ b/src/IconPacks.Avalonia/IconPacks.Avalonia.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia" />
+        <PackageReference Include="SkiaSharp" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IconPacks.Avalonia/PackIconControlDataFactory.cs
+++ b/src/IconPacks.Avalonia/PackIconControlDataFactory.cs
@@ -2,7 +2,10 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Threading.Tasks;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
 using IconPacks.Avalonia.Core;
 using IconPacks.Avalonia.BootstrapIcons;
 using IconPacks.Avalonia.BoxIcons;
@@ -40,6 +43,7 @@ using IconPacks.Avalonia.Unicons;
 using IconPacks.Avalonia.VaadinIcons;
 using IconPacks.Avalonia.WeatherIcons;
 using IconPacks.Avalonia.Zondicons;
+using SkiaSharp;
 
 namespace IconPacks.Avalonia
 {
@@ -53,6 +57,97 @@ namespace IconPacks.Avalonia
         static PackIconControlDataFactory()
         {
             DataIndex = new Lazy<ReadOnlyDictionary<Enum, string>>(() => new ReadOnlyDictionary<Enum, string>(GetAllIcons()));
+        }
+
+        public static string ProvideSvgPathData(Enum kind)
+        {
+            string data = null;
+            DataIndex.Value?.TryGetValue(kind, out data);
+            return data;
+        }
+
+        public static async Task<Bitmap> GetIconAsBitmapAsync(Enum kind, Color foreground, int width = 48, int height = 48)
+        {
+            try
+            {
+                await using var ms = new MemoryStream();
+            
+                await Task.Run(() =>
+                {
+                    var data = ProvideSvgPathData(kind);
+                    var skPath = SKPath.ParseSvgPathData(data);
+                    var originalBounds = skPath.Bounds;
+                    
+                    switch (kind)
+                    {
+                        case PackIconFeatherIconsKind:
+                            originalBounds.Inflate(2f, 2f);
+                            break;
+                    }
+                    
+                    if (width < 0) width = (int)(Math.Ceiling(originalBounds.Width));
+                    if (height < 0) height = (int)(Math.Ceiling(originalBounds.Height));
+
+                    float scaleX, scaleY;
+                    scaleX = scaleY = Math.Min(width / originalBounds.Width, height / originalBounds.Height);
+
+                    // For some icons we need to flip them 
+                    switch (kind)
+                    {
+                        case PackIconBootstrapIconsKind:
+                        case PackIconBoxIconsKind:
+                        case PackIconCodiconsKind:
+                        case PackIconCooliconsKind:
+                        case PackIconEvaIconsKind:
+                        case PackIconFileIconsKind:
+                        case PackIconFontaudioKind:
+                        case PackIconFontistoKind:
+                        case PackIconForkAwesomeKind:
+                        case PackIconJamIconsKind:
+                        case PackIconLucideKind:
+                        case PackIconRPGAwesomeKind:
+                        case PackIconTypiconsKind:
+                        case PackIconVaadinIconsKind:
+                            scaleY *= -1;
+                            break;
+                    }
+                    
+                    skPath.Transform(SKMatrix.CreateScale(scaleX, scaleY));
+                    skPath.Transform(SKMatrix.CreateTranslation( 
+                        - skPath.Bounds.Left + (width - skPath.Bounds.Width ) / 2,
+                        - skPath.Bounds.Top + (height - skPath.Bounds.Height ) / 2 ));
+                
+                    var skBitmap = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Premul);
+
+                    using var skCanvas = new SKCanvas(skBitmap);
+
+                    using var skPaint = new SKPaint();
+                    skPaint.IsAntialias = true;
+                    skPaint.Color = new SKColor(foreground.ToUInt32());
+
+                    switch (kind)
+                    {
+                        case PackIconFeatherIconsKind:
+                            skPaint.IsStroke = true;
+                            skPaint.StrokeCap = SKStrokeCap.Round;
+                            skPaint.StrokeWidth = 2 * scaleX;
+                            break;
+                    }
+
+                    skCanvas.DrawPath(skPath, skPaint);
+
+                    skBitmap.Encode(ms, SKEncodedImageFormat.Png, 100);
+
+                    ms.Seek(0, SeekOrigin.Begin);
+                });
+
+                return new Bitmap(ms);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return null;
+            }
         }
 
         internal static IDictionary<Enum, string> GetAllIcons()


### PR DESCRIPTION
Hey, 

this PR is solely meant to discuss the options we have. 
I noticed that having many icons rendered at the same time (for exmple in the icon pack browser) I can see a performance drop. This can be reduced if the icons are renderd outside the UIThread, however Avalonia doesn't allow this. 

## the idea

SkiaSharp (which is almost always available in standard Avalonia-Apps) can render the path into a Bitmap in an async manner. This can be consumed by the Avalonia app then. But this would require an API to get the data as a Bitmap. See code changes of this PR. 

## Additional idea
We have to care about Flipping the data in several places which one needs to track "by hand". Can't we have an attribute or property on the icon pack to read and process the data? The flip itself can even happen inside the proposed API to read the raw path. 