### PR TITLE
Use a more AOT friendly method for json deserialization

### DIFF
--- a/src/IconPacks.Avalonia.Core/PackIconDataFactory.cs
+++ b/src/IconPacks.Avalonia.Core/PackIconDataFactory.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization.Metadata;
+using System.Text.Json.Serialization;
 using Avalonia.Platform;
 
 namespace IconPacks.Avalonia.Core
 {
+    [JsonSerializable(typeof(Dictionary<string, string>))]
+    internal sealed partial class EnumDictionaryGenerationContext : JsonSerializerContext;
+
     public static class PackIconDataFactory<TEnum> where TEnum : struct, Enum
     {
         public static Lazy<ReadOnlyDictionary<TEnum, string>> DataIndex { get; }
@@ -19,13 +23,13 @@ namespace IconPacks.Avalonia.Core
         public static IDictionary<TEnum, string> Create()
         {
             using var iconJsonStream = AssetLoader.Open(new Uri($"avares://{typeof(TEnum).Assembly.GetName().Name}/Resources/Icons.json"));
-#pragma warning disable IL2026
-            var options = new JsonSerializerOptions
-            {
-                TypeInfoResolver = new DefaultJsonTypeInfoResolver()
-            };
-            return System.Text.Json.JsonSerializer.Deserialize<Dictionary<TEnum, string>>(iconJsonStream, options) ?? [];
-#pragma warning restore IL2026
+            var stringDictionary = System.Text.Json.JsonSerializer.Deserialize(iconJsonStream, EnumDictionaryGenerationContext.Default.DictionaryStringString) ?? [];
+#if NETSTANDARD2_0
+            return stringDictionary.ToDictionary(kvp => (TEnum)Enum.Parse(typeof(TEnum), kvp.Key), kvp => kvp.Value);
+#else
+            return stringDictionary.ToDictionary(kvp => Enum.Parse<TEnum>(kvp.Key), kvp => kvp.Value);
+#endif
+
         }
     }
 }


### PR DESCRIPTION
The existing method in general works, but throws an IL1026 warning while trimming. Theres no universal way in a generic to generate a per enum deserialization scheme.

However, since the keys are always strings, it is possible to deserialize into a Dictionary<string, string>. That dictionary can then be easily mapped into the typed enums.

NS2.0 is missing the fast enum parse function, so the code is conditionally compiled to NS2.0 and the other targets